### PR TITLE
add format and lint CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI Pipeline
+
+on:
+  # Triggers the workflow on push or pull request events but only for the "master" branch
+  pull_request:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          - backend
+          - frontend
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "npm"
+          cache-dependency-path: "${{ matrix.project }}/package-lock.json"
+
+      - name: Install npm packages
+        run: npm --prefix ./${{ matrix.project }} ci
+
+      - name: Vue type-check
+        if: ${{ matrix.project  == 'frontend' }}
+        run: npm --prefix ./${{ matrix.project }} run type-check
+
+      - name: Prettier
+        run: npm --prefix ./${{ matrix.project }} run format-check
+
+      - name: ESLint
+        run: npm --prefix ./${{ matrix.project }} run lint-check
+
+      # - name: Test
+      #   # Right now we only have test on backend
+      #   if: ${{ matrix.project  == 'backend' }}
+      #   run: npm --prefix ./${{ matrix.project }} run test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: "Code Scanning - Action"
+
+on:
+  pull_request:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+jobs:
+  CodeQL-Build:
+    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
+    runs-on: ubuntu-latest
+
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: javascript
+
+      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below).
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following
+      #    three lines and modify them (or add more) to build your code if your
+      #    project uses a compiled language
+
+      #- run: |
+      #     make bootstrap
+      #     make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,9 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "format-check": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint-check": "eslint \"{src,apps,libs,test}/**/*.ts\""
   },
   "dependencies": {
     "@nestjs/common": "^9.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "build-only": "vite build",
     "type-check": "vue-tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\" \"src/**/*.vue\"",
-    "lint": "eslint \"{src,test}/**/*.ts\" \"{src,test}/**/*.vue\" --fix"
+    "lint": "eslint \"{src,test}/**/*.ts\" \"{src,test}/**/*.vue\" --fix",
+    "format-check": "prettier --check \"src/**/*.ts\" \"src/**/*.vue\"",
+    "lint-check": "eslint \"{src,test}/**/*.ts\" \"{src,test}/**/*.vue\""
   },
   "dependencies": {
     "vue": "^3.2.38",


### PR DESCRIPTION
- [x] Format CI Pipeline
- [x] Lint CI Pipeline

Add [CodeQL](https://codeql.github.com/) Pipeline to check for security vulnerabilities such as SQL injection, etc but note it can take up to 2 mins for this CI Pipeline so if it becomes annoy we can disable and run it manually every now and then.

Add typescript check for front-end Vue because Vite (Vue build tool) doesn't check for type, more in [docs](https://vitejs.dev/guide/features.html#typescript)

Commented out test on back-end for now because we don't have one