### PR TITLE
Add debug docker compose file and debug rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 *.swp
 .DS_Store
+.idea

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "node",
+			"request": "attach",
+			"name": "Debug: attach to backend debugger",
+			"port": 9229,
+			"address": "localhost",
+			"localRoot": "${workspaceRoot}/backend",
+			"remoteRoot": "/app",
+		}
+	]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 DC := $(shell which docker-compose)
 
-
 PROD		:=	./docker-compose.prod.yaml
 DEV			:=	./docker-compose.yaml
+DEBUG		:=	./docker-compose.debug.yaml
 
 FRONT_NAME	:=	frontend
 BACK_NAME	:=	backend
@@ -16,12 +16,18 @@ dev: $(DEV)
 	$(DC) -f $(DEV) up --build --remove-orphans -d
 	$(DC) -f $(DEV) logs --tail 100 -f
 
+debug: $(DEBUG)
+	$(DC) -f $(DEBUG) up --build --remove-orphans -d
+	$(DC) -f $(DEBUG) logs --tail 100 -f
+
 stop:
 	-$(DC) -f $(DEV) stop
+	-$(DC) -f $(DEBUG) stop
 	-$(DC) -f $(PROD) stop
 
 clean: stop
 	-$(DC) -f $(DEV) down
+	-$(DC) -f $(DEBUG) down
 	-$(DC) -f $(PROD) down
 
 fclean: clean
@@ -30,6 +36,8 @@ fclean: clean
 redev: fclean dev
 
 reprod: fclean prod
+
+redebug: fclean debug
 
 norm:
 	$(DC) exec $(FRONT_NAME) npm run format
@@ -47,4 +55,4 @@ back:
 test:
 	$(DC) exec $(BACK_NAME) npm run test
 
-.PHONY: all prod dev stop clean fclean redev reprod norm front back
+.PHONY: all prod dev stop clean fclean redev reprod norm front back debug

--- a/Makefile
+++ b/Makefile
@@ -60,4 +60,4 @@ back:
 test:
 	$(DC) exec $(BACK_NAME) npm run test
 
-.PHONY: all prod dev stop clean fclean redev reprod norm front back debug volume
+.PHONY: all prod dev stop clean fclean redev reprod norm front back debug redebug volume

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "start:debug": "nest start --debug --watch",
+    "start:debug": "nest start --debug 0.0.0.0:9229 --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",

--- a/docker-compose.debug.yaml
+++ b/docker-compose.debug.yaml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+    database:
+        image: postgres:14-alpine
+        environment:
+            POSTGRES_PASSWORD: ${DB_PASSWORD} # Set in .env file
+            POSTGRES_DB: ${DB_NAME} # Set in .env file
+            POSTGRES_USER: ${DB_USERNAME} # Set in .env file
+        volumes:
+            - db_data:/var/lib/postgresql/data
+
+    backend:
+        build: ./tools/devcontainer
+        volumes:
+            - ${PWD}/backend:/app
+        ports:
+            - 8080:3000
+            - 9229:9229
+        command: /entrypoint.sh npm run start:debug
+        env_file:
+            - .env
+
+    frontend:
+        build: ./tools/devcontainer
+        volumes:
+            - ${PWD}/frontend:/app
+        ports:
+            - 80:5000
+        command: /entrypoint.sh npm run dev
+        env_file:
+            - .env
+
+volumes:
+    db_data:


### PR DESCRIPTION
- Add debug docker-compose file
- Add debug rule in Makefile
- Add default debug config for vscode
- Ignore .idea folder for webstorm config

### Usage
To use the debugger:
- run the debug rule `make debug`
- run vscode debug and select the config `attach to backend debugger`
- start debugging