### PR TITLE
124 save online status

### DIFF
--- a/backend/src/prc/prc.gateway.ts
+++ b/backend/src/prc/prc.gateway.ts
@@ -66,8 +66,14 @@ export class PrcGateway implements OnGatewayDisconnect {
 
   async handleDisconnect(@ConnectedSocket() client: Socket) {
     console.log('Client disconnected', client.id);
-    await this.usersService.updateStatus(client.id, 'offline');
-    await this.usersService.updateSocketId(client.id, '');
+    try {
+      await this.usersService.updateStatus(client.id, 'offline');
+      await this.usersService.updateSocketId(client.id, '');
+    } catch (EntityNotFoundError) {
+      // Do nothing.
+      // We need to do this to catch errors that arise if the socket
+      // information is not in the database yet. So this shouldn't be a problem.
+    }
   }
 
   @SubscribeMessage('newconnection')

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -1,5 +1,5 @@
 import { ObjectType, Field, Int } from '@nestjs/graphql';
-import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { Column, Entity, PrimaryColumn, Index } from 'typeorm';
 
 @ObjectType()
 @Entity()
@@ -18,6 +18,7 @@ export class User {
 
   @Field()
   @Column({ unique: true })
+  @Index()
   username: string;
 
   @Field()
@@ -49,5 +50,10 @@ export class User {
   twoFAEnable: boolean;
 
   @Column({ default: '' })
+  @Index()
   socketId: string;
+
+  @Field()
+  @Column({ default: 'offline' })
+  status: string;
 }

--- a/backend/src/users/memdb.mock.ts
+++ b/backend/src/users/memdb.mock.ts
@@ -16,7 +16,7 @@ export const testUser: User = {
   title: [''],
   twoFASecret: null,
   twoFAEnable: false,
-  socketId: '',
+  socketId: '98hf32-f3f',
   status: 'offline',
 };
 

--- a/backend/src/users/memdb.mock.ts
+++ b/backend/src/users/memdb.mock.ts
@@ -17,6 +17,7 @@ export const testUser: User = {
   twoFASecret: null,
   twoFAEnable: false,
   socketId: '',
+  status: 'offline',
 };
 
 export function getMockRepoProvider(key: string, entities: any, mockData: any) {

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -67,6 +67,7 @@ describe('UsersService', () => {
       twoFAEnable: false,
       socketId: '',
       title: [''],
+      status: 'offline',
     };
     await expect(service.create(newUser)).resolves.not.toThrow();
     await expect(service.findOne(12345)).resolves.toEqual(newUser);
@@ -86,6 +87,7 @@ describe('UsersService', () => {
       twoFAEnable: false,
       socketId: '',
       title: [''],
+      status: 'offline',
     };
     await expect(service.create(newerUser)).rejects.toThrow(QueryFailedError);
     await expect(service.findOne(testUser.id)).resolves.toEqual(testUser);
@@ -120,6 +122,7 @@ describe('UsersService', () => {
       twoFAEnable: false,
       socketId: '',
       title: [''],
+      status: 'offline',
     };
     await expect(service.create(newUser)).resolves.not.toThrow();
     await expect(
@@ -180,5 +183,26 @@ describe('UsersService', () => {
       service.updateSocketId(testUser.id, newUser.socketId),
     ).resolves.not.toThrow();
     await expect(service.findOne(testUser.id)).resolves.toEqual(newUser);
+  });
+
+  it('should not change socket id if not exists', async () => {
+    await expect(service.updateSocketId(87542, '98hf23')).rejects.toThrow(
+      EntityNotFoundError,
+    );
+  });
+
+  it('should update the status', async () => {
+    const newUser: User = testUser;
+    newUser.status = 'online';
+    await expect(
+      service.updateStatus(testUser.id, newUser.status),
+    ).resolves.not.toThrow();
+    await expect(service.findOne(testUser.id)).resolves.toEqual(newUser);
+  });
+
+  it('should not change status if not exists', async () => {
+    await expect(service.updateStatus(87542, 'offline')).rejects.toThrow(
+      EntityNotFoundError,
+    );
   });
 });

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -191,6 +191,21 @@ describe('UsersService', () => {
     );
   });
 
+  it('should update the socket id via socketId', async () => {
+    const newUser: User = testUser;
+    newUser.socketId = 'f3ie389hd';
+    await expect(
+      service.updateSocketId(testUser.socketId, newUser.socketId),
+    ).resolves.not.toThrow();
+    await expect(service.findOne(testUser.id)).resolves.toEqual(newUser);
+  });
+
+  it('should not change socket id via socketId if not exists', async () => {
+    await expect(service.updateSocketId('9gf3jhd', '98hf23')).rejects.toThrow(
+      EntityNotFoundError,
+    );
+  });
+
   it('should update the status', async () => {
     const newUser: User = testUser;
     newUser.status = 'online';
@@ -202,6 +217,21 @@ describe('UsersService', () => {
 
   it('should not change status if not exists', async () => {
     await expect(service.updateStatus(87542, 'offline')).rejects.toThrow(
+      EntityNotFoundError,
+    );
+  });
+
+  it('should update the status via socket-id', async () => {
+    const newUser: User = testUser;
+    newUser.status = 'online';
+    await expect(
+      service.updateStatus(newUser.socketId, 'online'),
+    ).resolves.not.toThrow();
+    await expect(service.findOne(testUser.id)).resolves.toEqual(newUser);
+  });
+
+  it('should not update the status via socket-id if not exists', async () => {
+    await expect(service.updateStatus('98zh3f09', 'online')).rejects.toThrow(
       EntityNotFoundError,
     );
   });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -63,4 +63,12 @@ export class UsersService {
     if (typeof result.affected != 'undefined' && result.affected < 1)
       throw new EntityNotFoundError(User, { id: id });
   }
+
+  async updateStatus(id: number, status: string): Promise<void> {
+    const result: UpdateResult = await this.userRepository.update(id, {
+      status: status,
+    });
+    if (typeof result.affected != 'undefined' && result.affected < 1)
+      throw new EntityNotFoundError(User, { id: id });
+  }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -56,19 +56,35 @@ export class UsersService {
       throw new EntityNotFoundError(User, { id: id });
   }
 
-  async updateSocketId(id: number, socketId: string): Promise<void> {
-    const result: UpdateResult = await this.userRepository.update(id, {
-      socketId: socketId,
-    });
+  async updateSocketId(
+    identification: number | string,
+    socketId: string,
+  ): Promise<void> {
+    const searchOptions: { id?: number; socketId?: string } = {};
+    if (typeof identification === 'number') searchOptions.id = identification;
+    else searchOptions.socketId = identification;
+    const result: UpdateResult = await this.userRepository.update(
+      searchOptions,
+      { socketId },
+    );
     if (typeof result.affected != 'undefined' && result.affected < 1)
-      throw new EntityNotFoundError(User, { id: id });
+      throw new EntityNotFoundError(User, { id: identification });
   }
 
-  async updateStatus(id: number, status: string): Promise<void> {
-    const result: UpdateResult = await this.userRepository.update(id, {
-      status: status,
-    });
+  async updateStatus(
+    identification: number | string,
+    status: string,
+  ): Promise<void> {
+    const searchOptions: { id?: number; socketId?: string } = {};
+    if (typeof identification === 'number') searchOptions.id = identification;
+    else searchOptions.socketId = identification;
+    const result: UpdateResult = await this.userRepository.update(
+      searchOptions,
+      {
+        status,
+      },
+    );
     if (typeof result.affected != 'undefined' && result.affected < 1)
-      throw new EntityNotFoundError(User, { id: id });
+      throw new EntityNotFoundError(User, { id: identification });
   }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -68,7 +68,7 @@ export class UsersService {
       { socketId },
     );
     if (typeof result.affected != 'undefined' && result.affected < 1)
-      throw new EntityNotFoundError(User, { id: identification });
+      throw new EntityNotFoundError(User, searchOptions);
   }
 
   async updateStatus(
@@ -85,6 +85,6 @@ export class UsersService {
       },
     );
     if (typeof result.affected != 'undefined' && result.affected < 1)
-      throw new EntityNotFoundError(User, { id: identification });
+      throw new EntityNotFoundError(User, searchOptions);
   }
 }

--- a/frontend/src/components/ChatChatComponent.vue
+++ b/frontend/src/components/ChatChatComponent.vue
@@ -10,8 +10,8 @@ const props = defineProps<{
 let text: Ref<string> = ref('');
 let messages: Ref<
   {
-    from: { id: number; username: string };
-    to: { id: number; username: string };
+    from: { id?: number; username: string };
+    to: { id?: number; username: string };
     msg: string;
   }[]
 > = ref([]);
@@ -24,6 +24,11 @@ socket.on('prc', (data) => {
 function sendMsg() {
   console.log(props.chatName, text.value);
   socket.emit('prc', { to: props.chatName, msg: text.value });
+  messages.value.push({
+    from: { username: 'Me' },
+    to: { username: props.chatName },
+    msg: text.value,
+  });
   text.value = '';
 }
 


### PR DESCRIPTION
- Update the User Entity to include the status (which is a string currently, we might want to change to an enum, to prevent unexpected values)
- Update User Service to update the status
- Update User Service to make changes to status and socketId via the socketId (we don't have the userid in the disconnect handler)
- Update tests to reflect changes
- You can now see your own messages in the message window on frontend