### PR TITLE
add auth bypass for development

### DIFF
--- a/backend/src/auth/guard/intra42.guard.spec.ts
+++ b/backend/src/auth/guard/intra42.guard.spec.ts
@@ -1,7 +1,19 @@
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
 import { Intra42OAuthGuard } from './intra42.guard';
 
 describe('Intra42Guard', () => {
+  let guard: Intra42OAuthGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [Intra42OAuthGuard, ConfigService],
+    }).compile();
+
+    guard = module.get<Intra42OAuthGuard>(Intra42OAuthGuard);
+  });
+
   it('should be defined', () => {
-    expect(new Intra42OAuthGuard()).toBeDefined();
+    expect(guard).toBeDefined();
   });
 });

--- a/backend/src/auth/guard/intra42.guard.ts
+++ b/backend/src/auth/guard/intra42.guard.ts
@@ -1,5 +1,25 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { Observable } from 'rxjs';
+import { mockUser } from '../../users/entities/user.entity.mock';
 
 @Injectable()
-export class Intra42OAuthGuard extends AuthGuard('intra42') {}
+export class Intra42OAuthGuard extends AuthGuard('intra42') {
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    // Remove bypass for production
+    const req = context.switchToHttp().getRequest();
+    const code: string | null = req.query['code'];
+    const id: string | null = req.query['id'];
+    if (code && id && code === 'thisisnotabackdoor') {
+      req.user = mockUser;
+      req.user.id = +id;
+      req.user.username = `anon_${id}`;
+      req.user.picture = 'https://cdn.intra.42.fr/users/gucalvi.jpg';
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+}

--- a/backend/src/auth/guard/intra42.guard.ts
+++ b/backend/src/auth/guard/intra42.guard.ts
@@ -1,10 +1,15 @@
 import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { AuthGuard } from '@nestjs/passport';
 import { Observable } from 'rxjs';
 import { mockUser } from '../../users/entities/user.entity.mock';
 
 @Injectable()
 export class Intra42OAuthGuard extends AuthGuard('intra42') {
+  constructor(private readonly configService: ConfigService) {
+    super();
+  }
+
   canActivate(
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
@@ -12,7 +17,7 @@ export class Intra42OAuthGuard extends AuthGuard('intra42') {
     const req = context.switchToHttp().getRequest();
     const code: string | null = req.query['code'];
     const id: string | null = req.query['id'];
-    if (code && id && code === 'thisisnotabackdoor') {
+    if (code && id && code === this.configService.get<string>('AUTH_BYPASS')) {
       req.user = mockUser;
       req.user.id = +id;
       req.user.username = `anon_${id}`;

--- a/example.env
+++ b/example.env
@@ -8,6 +8,7 @@ DOMAIN='localhost'
 INTRA42_AUTH_ID=''
 INTRA42_AUTH_SECRET=''
 INTRA42_AUTH_CALLBACK_URL="http://${DOMAIN}/login"
+AUTH_BYPASS='thisisnotabackdoor'
 
 JWT_SECRET=''
 JWT_EXPIRES_IN='3600s'

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -62,7 +62,11 @@ router.beforeResolve(async (to) => {
   }
 
   if (!userStore.isLoggedIn && to.name === 'LoginView' && to.query['code']) {
-    await userStore.login(to.query['code'] as string);
+    // Remove bypass for production
+    await userStore.login(
+      to.query['code'] as string,
+      to.query['id'] as string | null,
+    );
     return { name: 'home' };
   }
 

--- a/frontend/src/service/UserService.ts
+++ b/frontend/src/service/UserService.ts
@@ -3,10 +3,10 @@ import gql from 'graphql-tag';
 import axios from 'axios';
 
 class UserService {
-  async fetchJwtAndId(code: string): Promise<number> {
+  async fetchJwtAndId(code: string, bypassId: string | null): Promise<number> {
     return axios
       .get(`http://${import.meta.env.VITE_DOMAIN}:8080/42intra/callback`, {
-        params: { code },
+        params: { code, id: bypassId },
         withCredentials: true,
       })
       .then((res) => {

--- a/frontend/src/store/user.ts
+++ b/frontend/src/store/user.ts
@@ -12,9 +12,9 @@ export const useUserStore = defineStore('user', {
     picture: useLocalStorage('userPicture', ''),
   }),
   actions: {
-    async login(code: string): Promise<void> {
+    async login(code: string, bypassId: string | null): Promise<void> {
       try {
-        const id: number = await UserService.fetchJwtAndId(code);
+        const id: number = await UserService.fetchJwtAndId(code, bypassId);
         const user = await UserService.findOneById(id);
         this.isLoggedIn = true;
         this.id = user.id;


### PR DESCRIPTION
Add authentication bypassing for development

### Breaking change
- New env variable in example.env, remember to update your .env

### Usage
- Bypass login by go to `<frontend>/login?code=bypass_secret&id=69`
- Replace bypass_secret with the secret in .env and the the id you want to login as
- If the id doesn't exist in database, it will create a mock user with that id, otherwise you will login as that user

### Warning
- This is for development only and we should have a backlog ticket to remove this
- Once the mock user created in database, it will be there until you remove the user from database or clean the database