### PR TITLE
implement friendship system on backend

### DIFF
--- a/backend/src/tools/ExceptionFilter.ts
+++ b/backend/src/tools/ExceptionFilter.ts
@@ -1,0 +1,35 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
+import { GqlArgumentsHost, GqlExceptionFilter } from '@nestjs/graphql';
+import { ApolloError } from 'apollo-server-express';
+import { TypeORMError } from 'typeorm';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements GqlExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    GqlArgumentsHost.create(host);
+    return exception;
+  }
+}
+
+@Catch(TypeORMError)
+export class TypeORMErrorFilter implements GqlExceptionFilter {
+  catch(exception: TypeORMError, host: ArgumentsHost) {
+    GqlArgumentsHost.create(host);
+    return exception;
+  }
+}
+
+// To suppress nestjs from logging ApolloError
+// https://github.com/nestjs/graphql/issues/2060
+@Catch()
+export class AllExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown): any {
+    if (exception instanceof ApolloError) throw exception;
+    return exception;
+  }
+}

--- a/backend/src/users/dto/update-friendship.input.ts
+++ b/backend/src/users/dto/update-friendship.input.ts
@@ -1,0 +1,25 @@
+import { ArgsType, Field, Int, registerEnumType } from '@nestjs/graphql';
+import { IsNotEmpty } from 'class-validator';
+
+export enum AllowedUpdateFriendshipMethod {
+  ADD = 'add',
+  REMOVE = 'remove',
+  ACCEPT = 'accept',
+  DECLINE = 'decline',
+  CANCEL = 'cancel',
+}
+
+registerEnumType(AllowedUpdateFriendshipMethod, {
+  name: 'AllowedUpdateFriendshipMethod',
+});
+
+@ArgsType()
+export class UpdateUserFriendshipInput {
+  @IsNotEmpty()
+  @Field(() => AllowedUpdateFriendshipMethod)
+  method: AllowedUpdateFriendshipMethod;
+
+  @IsNotEmpty()
+  @Field(() => Int)
+  friendId: number;
+}

--- a/backend/src/users/entities/user.entity.mock.ts
+++ b/backend/src/users/entities/user.entity.mock.ts
@@ -3,7 +3,7 @@ import { User } from './user.entity';
 export const mockUser: User = {
   id: 84364,
   username: 'name',
-  picture: 'http://example.com',
+  picture: 'https://example.com',
   firstname: 'nobody',
   lastname: 'knows',
   email: 'nobody@example.com',
@@ -17,3 +17,22 @@ export const mockUser: User = {
   following: [],
   followers: [],
 };
+
+export const createMockUser = (options: Partial<User> = {}): User => ({
+  id: 12345,
+  username: 'test',
+  picture: 'https://example.com',
+  firstname: 'test',
+  lastname: 'person',
+  email: 'test@example.com',
+  country: 'Germany',
+  campus: 'Berlin',
+  twoFASecret: null,
+  twoFAEnable: false,
+  socketId: '',
+  title: [''],
+  status: 'offline',
+  following: [],
+  followers: [],
+  ...options,
+});

--- a/backend/src/users/entities/user.entity.mock.ts
+++ b/backend/src/users/entities/user.entity.mock.ts
@@ -14,4 +14,6 @@ export const mockUser: User = {
   twoFAEnable: false,
   socketId: '',
   status: 'offline',
+  following: [],
+  followers: [],
 };

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -1,6 +1,14 @@
-import { ObjectType, Field, Int } from '@nestjs/graphql';
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+import {
+  Column,
+  Entity,
+  Index,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+  PrimaryColumn,
+} from 'typeorm';
 import { ChannelUser } from '../../prc/channel/entities/channeluser.entity';
-import { OneToMany, Column, Entity, PrimaryColumn, Index } from 'typeorm';
 
 @ObjectType()
 @Entity()
@@ -56,6 +64,18 @@ export class User {
   @Field()
   @Column({ default: 'offline' })
   status: string;
+
+  @ManyToMany(() => User, (user) => user.followers, {
+    nullable: true,
+  })
+  @JoinTable()
+  following: User[];
+
+  @ManyToMany(() => User, (user) => user.following, {
+    cascade: true,
+    nullable: true,
+  })
+  followers: User[];
 
   @Field(() => [ChannelUser], { nullable: true })
   @OneToMany(() => ChannelUser, (channelUser) => channelUser.user, {

--- a/backend/src/users/users.resolver.ts
+++ b/backend/src/users/users.resolver.ts
@@ -1,7 +1,5 @@
 import {
   Args,
-  GqlArgumentsHost,
-  GqlExceptionFilter,
   Int,
   Mutation,
   Parent,
@@ -9,8 +7,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { ArgumentsHost, Catch, UseFilters, UseGuards } from '@nestjs/common';
-import { EntityNotFoundError } from 'typeorm';
+import { UseFilters, UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/guard/jwt.guard';
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
@@ -20,16 +17,9 @@ import { TwoFAGuard } from '../auth/guard/twoFA.guard';
 import { UpdateUserFriendshipInput } from './dto/update-friendship.input';
 import { CurrentJwtPayload } from './decorator/current-jwt-payload.decorator';
 import { JwtPayload } from '../auth/strategy/jwt.strategy';
+import { AllExceptionFilter } from '../tools/ExceptionFilter';
 
-@Catch(EntityNotFoundError)
-export class CatchOurExceptionsFilter implements GqlExceptionFilter {
-  catch(exception: EntityNotFoundError, host: ArgumentsHost) {
-    GqlArgumentsHost.create(host);
-    return exception;
-  }
-}
-
-@UseFilters(new CatchOurExceptionsFilter())
+@UseFilters(new AllExceptionFilter())
 @Resolver(() => User)
 @UseGuards(JwtAuthGuard, TwoFAGuard)
 export class UsersResolver {

--- a/backend/src/users/users.resolver.ts
+++ b/backend/src/users/users.resolver.ts
@@ -1,13 +1,15 @@
 import {
-  Mutation,
-  Resolver,
-  Query,
   Args,
-  Int,
-  GqlExceptionFilter,
   GqlArgumentsHost,
+  GqlExceptionFilter,
+  Int,
+  Mutation,
+  Parent,
+  Query,
+  ResolveField,
+  Resolver,
 } from '@nestjs/graphql';
-import { Catch, ArgumentsHost, UseFilters, UseGuards } from '@nestjs/common';
+import { ArgumentsHost, Catch, UseFilters, UseGuards } from '@nestjs/common';
 import { EntityNotFoundError } from 'typeorm';
 import { JwtAuthGuard } from '../auth/guard/jwt.guard';
 import { UsersService } from './users.service';
@@ -15,6 +17,9 @@ import { User } from './entities/user.entity';
 import { UpdateUserPictureInput } from './dto/update-userpicture.input';
 import { UpdateUserUsernameInput } from './dto/update-userusername.input';
 import { TwoFAGuard } from '../auth/guard/twoFA.guard';
+import { UpdateUserFriendshipInput } from './dto/update-friendship.input';
+import { CurrentJwtPayload } from './decorator/current-jwt-payload.decorator';
+import { JwtPayload } from '../auth/strategy/jwt.strategy';
 
 @Catch(EntityNotFoundError)
 export class CatchOurExceptionsFilter implements GqlExceptionFilter {
@@ -47,8 +52,7 @@ export class UsersResolver {
 
   @Query(() => User, { name: 'userChannelList' })
   async findUserChannelList(@Args('username') username: string) {
-    const result: User = await this.usersService.findUserChannelList(username);
-    return result;
+    return await this.usersService.findUserChannelList(username);
   }
 
   @Mutation(() => User)
@@ -71,5 +75,56 @@ export class UsersResolver {
       updateUserUsernameInput.username,
     );
     return this.usersService.findOne(updateUserUsernameInput.id);
+  }
+
+  @Mutation(() => User)
+  async updateFriendship(
+    @CurrentJwtPayload() user: JwtPayload,
+    @Args() args: UpdateUserFriendshipInput,
+  ): Promise<User> {
+    await this.usersService.updateFriendship(
+      user.id,
+      args.method,
+      args.friendId,
+    );
+    return this.usersService.findOne(user.id);
+  }
+
+  @ResolveField(() => [User])
+  async friends(@Parent() user: User): Promise<User[]> {
+    if (
+      typeof user.following === 'undefined' ||
+      typeof user.followers === 'undefined'
+    )
+      return [];
+    return user.followers.filter((follower) =>
+      user.following.some((following) => following.id === follower.id),
+    );
+  }
+
+  @ResolveField(() => [User])
+  async sentFriendRequests(@Parent() user: User): Promise<User[]> {
+    if (
+      typeof user.following === 'undefined' ||
+      typeof user.followers === 'undefined'
+    )
+      return [];
+    return user.following.filter(
+      (following) =>
+        !user.followers.some((follower) => follower.id === following.id),
+    );
+  }
+
+  @ResolveField(() => [User])
+  async receivedFriendRequests(@Parent() user: User): Promise<User[]> {
+    if (
+      typeof user.following === 'undefined' ||
+      typeof user.followers === 'undefined'
+    )
+      return [];
+    return user.followers.filter(
+      (follower) =>
+        !user.following.some((following) => following.id === follower.id),
+    );
   }
 }

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -70,6 +70,8 @@ describe('UsersService', () => {
       socketId: '',
       title: [''],
       status: 'offline',
+      following: [],
+      followers: [],
     };
     await expect(service.create(newUser)).resolves.not.toThrow();
     await expect(service.findOne(12345)).resolves.toEqual(newUser);
@@ -91,6 +93,8 @@ describe('UsersService', () => {
       socketId: '',
       title: [''],
       status: 'offline',
+      following: [],
+      followers: [],
     };
     await expect(service.create(newerUser)).rejects.toThrow(QueryFailedError);
     await expect(service.findOne(testUser.id)).resolves.toEqual(testUser);
@@ -125,6 +129,8 @@ describe('UsersService', () => {
       socketId: '',
       title: [''],
       status: 'offline',
+      following: [],
+      followers: [],
     };
     await expect(service.create(newUser)).resolves.not.toThrow();
     await expect(

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,9 +1,9 @@
-import { TestingModule, Test } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
-import { mockUser } from './entities/user.entity.mock';
+import { createMockUser, mockUser } from './entities/user.entity.mock';
 import { MockRepo } from '../tools/memdb.mock';
-import { QueryFailedError, EntityNotFoundError } from 'typeorm';
+import { EntityNotFoundError, QueryFailedError } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 
 describe('UsersService', () => {
@@ -56,46 +56,14 @@ describe('UsersService', () => {
   });
 
   it('should create a new user', async () => {
-    const newUser: User = {
-      id: 12345,
-      username: 'test',
-      picture: 'http://example.com',
-      firstname: 'test',
-      lastname: 'person',
-      email: 'test@example.com',
-      country: 'Germany',
-      campus: 'Berlin',
-      twoFASecret: null,
-      twoFAEnable: false,
-      socketId: '',
-      title: [''],
-      status: 'offline',
-      following: [],
-      followers: [],
-    };
+    const newUser: User = createMockUser();
     await expect(service.create(newUser)).resolves.not.toThrow();
     await expect(service.findOne(12345)).resolves.toEqual(newUser);
   });
 
   it('should not create a user if existing', async () => {
     const testUser = mockRepo.getTestEntity();
-    const newerUser: User = {
-      id: testUser.id,
-      username: 'nanu',
-      picture: 'http://example.com',
-      firstname: 'foo',
-      lastname: 'bar',
-      email: 'test@example.com',
-      country: 'Dreamland',
-      campus: 'Shipwreckia',
-      twoFASecret: null,
-      twoFAEnable: false,
-      socketId: '',
-      title: [''],
-      status: 'offline',
-      following: [],
-      followers: [],
-    };
+    const newerUser: User = createMockUser({ id: testUser.id });
     await expect(service.create(newerUser)).rejects.toThrow(QueryFailedError);
     await expect(service.findOne(testUser.id)).resolves.toEqual(testUser);
   });
@@ -115,23 +83,7 @@ describe('UsersService', () => {
   });
 
   it('should not change the username if not unique', async () => {
-    const newUser: User = {
-      id: 12345,
-      username: 'test',
-      picture: 'http://example.com',
-      firstname: 'test',
-      lastname: 'person',
-      email: 'test@example.com',
-      country: 'Germany',
-      campus: 'Berlin',
-      twoFASecret: null,
-      twoFAEnable: false,
-      socketId: '',
-      title: [''],
-      status: 'offline',
-      following: [],
-      followers: [],
-    };
+    const newUser: User = createMockUser();
     await expect(service.create(newUser)).resolves.not.toThrow();
     await expect(
       service.updateUsername(newUser.id, mockRepo.getTestEntity().username),
@@ -141,7 +93,7 @@ describe('UsersService', () => {
 
   it('should change the picture', async () => {
     const newUser: User = mockRepo.getTestEntity();
-    newUser.picture = 'http://whoknows.com';
+    newUser.picture = 'https://whoknows.com';
     await expect(
       service.updatePicture(newUser.id, newUser.picture),
     ).resolves.not.toThrow();

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -4,6 +4,7 @@ import { User } from './entities/user.entity';
 import { EntityNotFoundError, Repository, UpdateResult } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AllowedUpdateFriendshipMethod } from './dto/update-friendship.input';
+import { UserInputError } from 'apollo-server-express';
 
 @Injectable()
 export class UsersService {
@@ -115,7 +116,7 @@ export class UsersService {
     friendId: number,
   ): Promise<void> {
     if (id === friendId)
-      throw new Error('You cannot send a friend request to yourself');
+      throw new UserInputError('You cannot send a friend request to yourself');
     const users: User[] = await this.userRepository.find({
       where: [{ id }, { id: friendId }],
       relations: ['following', 'followers'],
@@ -134,7 +135,7 @@ export class UsersService {
         user.following.some((following) => following.id === friendId) ||
         friend.following.some((following) => following.id === id)
       )
-        throw new Error('Failed to send friend request');
+        throw new UserInputError('Failed to send friend request');
 
       user.following.push(friend);
       await this.userRepository.save(user);
@@ -145,7 +146,7 @@ export class UsersService {
         !user.following.some((following) => following.id === friendId) ||
         !friend.following.some((following) => following.id === id)
       )
-        throw new Error('Failed to remove friend');
+        throw new UserInputError('Failed to remove friend');
 
       user.following = user.following.filter(
         (following) => following.id !== friendId,
@@ -161,7 +162,7 @@ export class UsersService {
         user.following.some((following) => following.id === friendId) ||
         !friend.following.some((following) => following.id === id)
       ) {
-        throw new Error('Failed to accept friend request');
+        throw new UserInputError('Failed to accept friend request');
       }
       user.following.push(friend);
       await this.userRepository.save(user);
@@ -172,7 +173,7 @@ export class UsersService {
         user.following.some((following) => following.id === friendId) ||
         !friend.following.some((following) => following.id === id)
       )
-        throw new Error('Failed to decline friend request');
+        throw new UserInputError('Failed to decline friend request');
 
       friend.following = friend.following.filter(
         (following) => following.id !== id,
@@ -185,13 +186,12 @@ export class UsersService {
         !user.following.some((following) => following.id === friendId) ||
         friend.following.some((following) => following.id === id)
       ) {
-        throw new Error('Failed to cancel friend request');
+        throw new UserInputError('Failed to cancel friend request');
       }
       user.following = user.following.filter(
         (following) => following.id !== friendId,
       );
       await this.userRepository.save(user);
     }
-    return;
   }
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@nestjs/common';
 import { CreateUserInput } from './dto/create-user.input';
 import { User } from './entities/user.entity';
-import { Repository, EntityNotFoundError, UpdateResult } from 'typeorm';
+import { EntityNotFoundError, Repository, UpdateResult } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
+import { AllowedUpdateFriendshipMethod } from './dto/update-friendship.input';
 
 @Injectable()
 export class UsersService {
@@ -12,16 +13,6 @@ export class UsersService {
 
   create(createUserInput: CreateUserInput) {
     return this.userRepository.insert(createUserInput);
-  }
-
-  findAll(): Promise<User[]> {
-    return this.userRepository.find();
-  }
-
-  findOne(identifier: number | string): Promise<User> {
-    if (typeof identifier == 'number')
-      return this.userRepository.findOneByOrFail({ id: identifier });
-    else return this.userRepository.findOneByOrFail({ username: identifier });
   }
 
   findUserChannelList(identifier: number | string): Promise<User> {
@@ -51,6 +42,23 @@ export class UsersService {
     });
     if (typeof result.affected != 'undefined' && result.affected < 1)
       throw new EntityNotFoundError(User, { id: id });
+  }
+
+  findAll(): Promise<User[]> {
+    return this.userRepository.find({ relations: ['following', 'followers'] });
+  }
+
+  findOne(identifier: number | string): Promise<User> {
+    if (typeof identifier == 'number')
+      return this.userRepository.findOneOrFail({
+        where: { id: identifier },
+        relations: ['following', 'followers'],
+      });
+    else
+      return this.userRepository.findOneOrFail({
+        where: { username: identifier },
+        relations: ['following', 'followers'],
+      });
   }
 
   async updatePicture(id: number, picture: string): Promise<void> {
@@ -99,5 +107,91 @@ export class UsersService {
     );
     if (typeof result.affected != 'undefined' && result.affected < 1)
       throw new EntityNotFoundError(User, searchOptions);
+  }
+
+  async updateFriendship(
+    id: number,
+    method: AllowedUpdateFriendshipMethod,
+    friendId: number,
+  ): Promise<void> {
+    if (id === friendId)
+      throw new Error('You cannot send a friend request to yourself');
+    const users: User[] = await this.userRepository.find({
+      where: [{ id }, { id: friendId }],
+      relations: ['following', 'followers'],
+    });
+    const user: User | undefined = users.find((user) => user.id === id);
+    const friend: User | undefined = users.find((user) => user.id === friendId);
+    if (typeof user == 'undefined') {
+      throw new EntityNotFoundError(User, id);
+    }
+    if (typeof friend == 'undefined') {
+      throw new EntityNotFoundError(User, friendId);
+    }
+
+    if (method === AllowedUpdateFriendshipMethod.ADD) {
+      if (
+        user.following.some((following) => following.id === friendId) ||
+        friend.following.some((following) => following.id === id)
+      )
+        throw new Error('Failed to send friend request');
+
+      user.following.push(friend);
+      await this.userRepository.save(user);
+    }
+
+    if (method === AllowedUpdateFriendshipMethod.REMOVE) {
+      if (
+        !user.following.some((following) => following.id === friendId) ||
+        !friend.following.some((following) => following.id === id)
+      )
+        throw new Error('Failed to remove friend');
+
+      user.following = user.following.filter(
+        (following) => following.id !== friendId,
+      );
+      friend.following = friend.following.filter(
+        (following) => following.id !== id,
+      );
+      await this.userRepository.save([friend, user]);
+    }
+
+    if (method === AllowedUpdateFriendshipMethod.ACCEPT) {
+      if (
+        user.following.some((following) => following.id === friendId) ||
+        !friend.following.some((following) => following.id === id)
+      ) {
+        throw new Error('Failed to accept friend request');
+      }
+      user.following.push(friend);
+      await this.userRepository.save(user);
+    }
+
+    if (method === AllowedUpdateFriendshipMethod.DECLINE) {
+      if (
+        user.following.some((following) => following.id === friendId) ||
+        !friend.following.some((following) => following.id === id)
+      )
+        throw new Error('Failed to decline friend request');
+
+      friend.following = friend.following.filter(
+        (following) => following.id !== id,
+      );
+      await this.userRepository.save(friend);
+    }
+
+    if (method === AllowedUpdateFriendshipMethod.CANCEL) {
+      if (
+        !user.following.some((following) => following.id === friendId) ||
+        friend.following.some((following) => following.id === id)
+      ) {
+        throw new Error('Failed to cancel friend request');
+      }
+      user.following = user.following.filter(
+        (following) => following.id !== friendId,
+      );
+      await this.userRepository.save(user);
+    }
+    return;
   }
 }


### PR DESCRIPTION
### User entity
- 2 new column following and followers as a user array type to keep track friendship
- these 2 column are ManyToMany (user to user) relationship
- following is a list of user you follow and inversely bind to the followed user followers column
- followers is a list of user that followed you and inversely bind to the followed user following column

### User GraphQL
- new graphql mutation to add/remove/accept/decline/cancel friend
- new fields for User type: `friends`, `sentFriendRequests`, `receivedFriendRequests`
- those fields are `ResolveField` and will return accordingly by filtering out from the following and followers column

### Limitation
- overhead of keeping track of 2 column with duplicating value
- no metadata of friendship (example: timestamp when both are friends)

But this is the easier way to do it without having to create and store a new separated entity

### Others
- right now `UsersService.find` and `findAll` will always query with relations which can be an overhead if we don't need them
- no test for the friendship system yet (haven't found an elegant way to do this because of the database relations)
- add mock user factory
