### PR TITLE
Protect GraphQL Mutations

### DIFF
--- a/backend/src/users/dto/update-userpicture.input.ts
+++ b/backend/src/users/dto/update-userpicture.input.ts
@@ -1,12 +1,8 @@
-import { InputType, Field, Int } from '@nestjs/graphql';
+import { ArgsType, Field } from '@nestjs/graphql';
 import { IsUrl, IsNotEmpty } from 'class-validator';
 
-@InputType()
+@ArgsType()
 export class UpdateUserPictureInput {
-  @IsNotEmpty()
-  @Field(() => Int)
-  id: number;
-
   @IsNotEmpty()
   @IsUrl()
   @Field()

--- a/backend/src/users/dto/update-userusername.input.ts
+++ b/backend/src/users/dto/update-userusername.input.ts
@@ -1,13 +1,10 @@
-import { InputType, Field, Int } from '@nestjs/graphql';
-import { IsNotEmpty } from 'class-validator';
+import { ArgsType, Field } from '@nestjs/graphql';
+import { IsNotEmpty, Length } from 'class-validator';
 
-@InputType()
+@ArgsType()
 export class UpdateUserUsernameInput {
   @IsNotEmpty()
-  @Field(() => Int)
-  id: number;
-
-  @IsNotEmpty()
   @Field()
+  @Length(1, 42)
   username: string;
 }

--- a/backend/src/users/users.resolver.spec.ts
+++ b/backend/src/users/users.resolver.spec.ts
@@ -74,13 +74,30 @@ describe('UsersResolver', () => {
       picture: newUser.picture,
     };
     await expect(
-      resolver.updatePicture(updateUserPictureInput),
+      resolver.updatePicture(updateUserPictureInput, newUser),
     ).resolves.toEqual(newUser);
+  });
+
+  it('should not update other users picture', async () => {
+    const newUser = mockRepo.getTestEntity({
+      picture: 'heyho',
+    });
+    const testUser = mockRepo.getTestEntity({
+      id: 12345,
+      picture: 'hoho',
+    });
+    const updateUserPictureInput: UpdateUserPictureInput = {
+      id: newUser.id,
+      picture: newUser.picture,
+    };
+    await expect(
+      resolver.updatePicture(updateUserPictureInput, testUser),
+    ).rejects.toThrow(Error);
   });
 
   it('should not update a users picture if user not exist', async () => {
     const newUser = mockRepo.getTestEntity({
-      id: 12345,
+      id: 678,
       picture: 'http://test.whoknows.xyz',
     });
     const updateUserPictureInput: UpdateUserPictureInput = {
@@ -88,7 +105,7 @@ describe('UsersResolver', () => {
       picture: newUser.picture,
     };
     await expect(
-      resolver.updatePicture(updateUserPictureInput),
+      resolver.updatePicture(updateUserPictureInput, newUser),
     ).rejects.toThrow(EntityNotFoundError);
   });
 
@@ -99,17 +116,37 @@ describe('UsersResolver', () => {
       username: newUser.username,
     };
     await expect(
-      resolver.updateUsername(updateUserUsernameInput),
+      resolver.updateUsername(updateUserUsernameInput, newUser),
     ).resolves.toEqual(newUser);
   });
 
-  it('should not update a users username if not exist', async () => {
+  it('should not update other users username', async () => {
+    const newUser = mockRepo.getTestEntity({
+      username: 'heyho',
+    });
+    const testUser = mockRepo.getTestEntity({
+      id: 12345,
+      username: 'hoho',
+    });
     const updateUserUsernameInput: UpdateUserUsernameInput = {
-      id: 948624,
+      id: newUser.id,
+      username: newUser.username,
+    };
+    await expect(
+      resolver.updateUsername(updateUserUsernameInput, testUser),
+    ).rejects.toThrow(Error);
+  });
+
+  it('should not update a users username if not exist', async () => {
+    const newUser = mockRepo.getTestEntity({
+      id: 8974632,
+    });
+    const updateUserUsernameInput: UpdateUserUsernameInput = {
+      id: newUser.id,
       username: 'nothingtwice',
     };
     await expect(
-      resolver.updateUsername(updateUserUsernameInput),
+      resolver.updateUsername(updateUserUsernameInput, newUser),
     ).rejects.toThrow(EntityNotFoundError);
   });
 });

--- a/backend/src/users/users.resolver.spec.ts
+++ b/backend/src/users/users.resolver.spec.ts
@@ -70,29 +70,11 @@ describe('UsersResolver', () => {
       picture: 'http://test.whoknows.xyz',
     });
     const updateUserPictureInput: UpdateUserPictureInput = {
-      id: newUser.id,
       picture: newUser.picture,
     };
     await expect(
       resolver.updatePicture(updateUserPictureInput, newUser),
     ).resolves.toEqual(newUser);
-  });
-
-  it('should not update other users picture', async () => {
-    const newUser = mockRepo.getTestEntity({
-      picture: 'heyho',
-    });
-    const testUser = mockRepo.getTestEntity({
-      id: 12345,
-      picture: 'hoho',
-    });
-    const updateUserPictureInput: UpdateUserPictureInput = {
-      id: newUser.id,
-      picture: newUser.picture,
-    };
-    await expect(
-      resolver.updatePicture(updateUserPictureInput, testUser),
-    ).rejects.toThrow(Error);
   });
 
   it('should not update a users picture if user not exist', async () => {
@@ -101,7 +83,6 @@ describe('UsersResolver', () => {
       picture: 'http://test.whoknows.xyz',
     });
     const updateUserPictureInput: UpdateUserPictureInput = {
-      id: newUser.id,
       picture: newUser.picture,
     };
     await expect(
@@ -112,7 +93,6 @@ describe('UsersResolver', () => {
   it('should update a users username', async () => {
     const newUser = mockRepo.getTestEntity({ username: 'testUser' });
     const updateUserUsernameInput: UpdateUserUsernameInput = {
-      id: newUser.id,
       username: newUser.username,
     };
     await expect(
@@ -120,29 +100,11 @@ describe('UsersResolver', () => {
     ).resolves.toEqual(newUser);
   });
 
-  it('should not update other users username', async () => {
-    const newUser = mockRepo.getTestEntity({
-      username: 'heyho',
-    });
-    const testUser = mockRepo.getTestEntity({
-      id: 12345,
-      username: 'hoho',
-    });
-    const updateUserUsernameInput: UpdateUserUsernameInput = {
-      id: newUser.id,
-      username: newUser.username,
-    };
-    await expect(
-      resolver.updateUsername(updateUserUsernameInput, testUser),
-    ).rejects.toThrow(Error);
-  });
-
   it('should not update a users username if not exist', async () => {
     const newUser = mockRepo.getTestEntity({
       id: 8974632,
     });
     const updateUserUsernameInput: UpdateUserUsernameInput = {
-      id: newUser.id,
       username: 'nothingtwice',
     };
     await expect(

--- a/backend/src/users/users.resolver.ts
+++ b/backend/src/users/users.resolver.ts
@@ -54,29 +54,25 @@ export class UsersResolver {
 
   @Mutation(() => User)
   async updatePicture(
-    @Args('user') updateUserPictureInput: UpdateUserPictureInput,
+    @Args() updateUserPictureInput: UpdateUserPictureInput,
     @CurrentUser() user: User,
   ) {
-    if (user.id != updateUserPictureInput.id)
-      throw new Error('Missing Permissions to change other User');
     await this.usersService.updatePicture(
-      updateUserPictureInput.id,
+      user.id,
       updateUserPictureInput.picture,
     );
-    return this.usersService.findOne(updateUserPictureInput.id);
+    return this.usersService.findOne(user.id);
   }
 
   @Mutation(() => User)
   async updateUsername(
-    @Args('user') updateUserUsernameInput: UpdateUserUsernameInput,
+    @Args() updateUserUsernameInput: UpdateUserUsernameInput,
     @CurrentUser() user: User,
   ) {
-    if (user.id != updateUserUsernameInput.id)
-      throw new Error('Missing Permissions to change other User');
     await this.usersService.updateUsername(
-      updateUserUsernameInput.id,
+      user.id,
       updateUserUsernameInput.username,
     );
-    return this.usersService.findOne(updateUserUsernameInput.id);
+    return this.usersService.findOne(user.id);
   }
 }

--- a/backend/src/users/users.resolver.ts
+++ b/backend/src/users/users.resolver.ts
@@ -15,7 +15,8 @@ import { User } from './entities/user.entity';
 import { UpdateUserPictureInput } from './dto/update-userpicture.input';
 import { UpdateUserUsernameInput } from './dto/update-userusername.input';
 import { TwoFAGuard } from '../auth/guard/twoFA.guard';
-import { CurrentUser } from './decorator/current-user.decorator';
+import { CurrentJwtPayload } from './decorator/current-jwt-payload.decorator';
+import { JwtPayload } from '../auth/strategy/jwt.strategy';
 
 @Catch(EntityNotFoundError)
 export class CatchOurExceptionsFilter implements GqlExceptionFilter {
@@ -55,7 +56,7 @@ export class UsersResolver {
   @Mutation(() => User)
   async updatePicture(
     @Args() updateUserPictureInput: UpdateUserPictureInput,
-    @CurrentUser() user: User,
+    @CurrentJwtPayload() user: JwtPayload,
   ) {
     await this.usersService.updatePicture(
       user.id,
@@ -67,7 +68,7 @@ export class UsersResolver {
   @Mutation(() => User)
   async updateUsername(
     @Args() updateUserUsernameInput: UpdateUserUsernameInput,
-    @CurrentUser() user: User,
+    @CurrentJwtPayload() user: JwtPayload,
   ) {
     await this.usersService.updateUsername(
       user.id,

--- a/backend/src/users/users.resolver.ts
+++ b/backend/src/users/users.resolver.ts
@@ -15,6 +15,7 @@ import { User } from './entities/user.entity';
 import { UpdateUserPictureInput } from './dto/update-userpicture.input';
 import { UpdateUserUsernameInput } from './dto/update-userusername.input';
 import { TwoFAGuard } from '../auth/guard/twoFA.guard';
+import { CurrentUser } from './decorator/current-user.decorator';
 
 @Catch(EntityNotFoundError)
 export class CatchOurExceptionsFilter implements GqlExceptionFilter {
@@ -54,7 +55,10 @@ export class UsersResolver {
   @Mutation(() => User)
   async updatePicture(
     @Args('user') updateUserPictureInput: UpdateUserPictureInput,
+    @CurrentUser() user: User,
   ) {
+    if (user.id != updateUserPictureInput.id)
+      throw new Error('Missing Permissions to change other User');
     await this.usersService.updatePicture(
       updateUserPictureInput.id,
       updateUserPictureInput.picture,
@@ -65,7 +69,10 @@ export class UsersResolver {
   @Mutation(() => User)
   async updateUsername(
     @Args('user') updateUserUsernameInput: UpdateUserUsernameInput,
+    @CurrentUser() user: User,
   ) {
+    if (user.id != updateUserUsernameInput.id)
+      throw new Error('Missing Permissions to change other User');
     await this.usersService.updateUsername(
       updateUserUsernameInput.id,
       updateUserUsernameInput.username,


### PR DESCRIPTION
I changed from asking for the id and the new username/picture, to just asking for the picture and reading the user id from the jwt. Now you can only change your own picture/username and not of literally anyone