### PR TITLE
Remove Channel create Mutation

### DIFF
--- a/backend/src/prc/channel/channel.resolver.ts
+++ b/backend/src/prc/channel/channel.resolver.ts
@@ -29,12 +29,6 @@ export class ChannelResolver {
   }
 
   @Mutation(() => Channel)
-  async createChannel(@Args() createChannelInput: CreateChannelInput) {
-    const id = await this.channelService.create(createChannelInput);
-    return this.channelService.findOne(id);
-  }
-
-  @Mutation(() => Channel)
   async joinChannel(
     @Args() createChannelInput: CreateChannelInput,
     @CurrentUser() user: User,


### PR DESCRIPTION
Since the channel creation is handled in the join service/mutation, we don't want to give the user the possibility to create a channel without joining it.