### PR TITLE
Add schema.gql for documentation purposes

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,10 +9,22 @@ import { User } from './users/entities/user.entity';
 import { ChannelUser } from './prc/channel/entities/channeluser.entity';
 import { Channel } from './prc/channel/entities/channel.entity';
 import { HealthModule } from './health/health.module';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 
 @Module({
   imports: [
     ConfigModule.forRoot({ isGlobal: true, expandVariables: true }),
+    GraphQLModule.forRoot<ApolloDriverConfig>({
+      driver: ApolloDriver,
+      debug: true,
+      playground: true,
+      autoSchemaFile: 'src/schema.gql',
+      cors: {
+        origin: `http://${process.env.DOMAIN}`,
+        credentials: true,
+      },
+    }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -1,0 +1,70 @@
+# ------------------------------------------------------
+# THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
+# ------------------------------------------------------
+
+type Channel {
+  id: Int!
+  name: String!
+  private: Boolean!
+  userList: [ChannelUser!]!
+}
+
+type ChannelUser {
+  id: Int!
+  user_id: Int!
+  channel_name: String!
+  admin: Boolean!
+  owner: Boolean!
+  ban: Boolean!
+  unbantime: DateTime!
+  mute: Boolean!
+  unmutetime: DateTime!
+}
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
+type User {
+  id: Int!
+  firstname: String!
+  lastname: String!
+  username: String!
+  email: String!
+  picture: String!
+  campus: String!
+  country: String!
+  title: [String!]!
+  twoFAEnable: Boolean!
+  status: String!
+  channelList: [ChannelUser!]
+  friends: [User!]!
+  sentFriendRequests: [User!]!
+  receivedFriendRequests: [User!]!
+}
+
+type Query {
+  users: [User!]!
+  user(id: Int): User!
+  userByName(username: String!): User!
+  userChannelList(username: String!): User!
+  channels: [Channel!]!
+  channel(id: Int!): Channel!
+  channelByName(name: String!): Channel!
+}
+
+type Mutation {
+  updatePicture(picture: String!): User!
+  updateUsername(username: String!): User!
+  updateFriendship(method: AllowedUpdateFriendshipMethod!, friendId: Int!): User!
+  joinChannel(name: String!, password: String!): Channel!
+}
+
+enum AllowedUpdateFriendshipMethod {
+  ADD
+  REMOVE
+  ACCEPT
+  DECLINE
+  CANCEL
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,26 +1,12 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersResolver } from './users.resolver';
-import { GraphQLModule } from '@nestjs/graphql';
-import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { UserPipe } from './decorator/user-pipe.service';
 
 @Module({
-  imports: [
-    GraphQLModule.forRoot<ApolloDriverConfig>({
-      driver: ApolloDriver,
-      debug: true,
-      playground: true,
-      autoSchemaFile: true,
-      cors: {
-        origin: `http://${process.env.DOMAIN}`,
-        credentials: true,
-      },
-    }),
-    TypeOrmModule.forFeature([User]),
-  ],
+  imports: [TypeOrmModule.forFeature([User])],
   providers: [UsersResolver, UsersService, UserPipe],
   exports: [UsersService],
 })


### PR DESCRIPTION
`backend/src/schema.gql` now holds a writeup of our GraphQL Schema for reference while building new stuff